### PR TITLE
Fix/cuda transfer error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 with open('README.md', 'r') as fh:
     long_description = fh.read()
 
-version = '0.0.7'
+version = '0.0.8'
 
 setup(
     name='flashtorch',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,9 @@ setup(
         'importlib_resources'
     ],
     classifiers=[
-        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
     ],

--- a/tests/test_backprop.py
+++ b/tests/test_backprop.py
@@ -220,11 +220,11 @@ def test_warn_when_prediction_is_wrong(mocker, model):
 
 def test_register_backward_hook_to_first_conv_layer(mocker, available_models):
     print()
-    for name, model in available_models:
+    for name, model_module in available_models:
         print(f'Testing model: {name}', end='\r')
         stdout.write('\x1b[2K')
 
-        model = model()
+        model = model_module()
 
         conv_layer = find_first_conv_layer(model, nn.modules.conv.Conv2d, 3)
         mocker.spy(conv_layer, 'register_backward_hook')
@@ -236,11 +236,11 @@ def test_register_backward_hook_to_first_conv_layer(mocker, available_models):
 
 def test_register_hooks_to_relu_layers(mocker, available_models):
     print()
-    for name, model in available_models:
+    for name, model_module in available_models:
         print(f'Testing model: {name}', end='\r')
         stdout.write('\x1b[2K')
 
-        model = model()
+        model = model_module()
 
         relu_layers = find_relu_layers(model,nn.ReLU)
 
@@ -268,11 +268,11 @@ def test_register_hooks_to_relu_layers(mocker, available_models):
 
 def test_calculate_gradients_for_all_models(mocker, available_models):
     print()
-    for name, model in available_models:
+    for name, model_module in available_models:
         print(f'Testing model: {name}', end='\r')
         stdout.write('\x1b[2K')
 
-        model = model()
+        model = model_module()
         backprop = Backprop(model)
 
         target_class = 5
@@ -283,7 +283,9 @@ def test_calculate_gradients_for_all_models(mocker, available_models):
 
         make_mock_output(mocker, model, target_class)
 
-        gradients = backprop.calculate_gradients(input_, target_class)
+        gradients = backprop.calculate_gradients(input_,
+                                                 target_class,
+                                                 use_gpu=True)
 
         assert gradients.shape == input_.size()[1:]
 


### PR DESCRIPTION
This PR fixes an error mentioned in #2.
This was happening due to `target` tensor not being transferred to GPU.

This PR also introduces an API change to `Backprop.calculate_gradient` method.
Users can now explicitly set which device to use via `use_gpu` flag, which is set to `False` by default.