### PR TITLE
fix: added checks to prevent errors when parameter gradients were disabled 

### DIFF
--- a/flashtorch/saliency/backprop.py
+++ b/flashtorch/saliency/backprop.py
@@ -214,6 +214,7 @@ class Backprop:
 
     def _register_conv_hook(self):
         def _record_gradients(module, grad_in, grad_out):
+            if grad_in[0] is None: return
             if self.gradients.shape == grad_in[0].shape:
                 self.gradients = grad_in[0]
 
@@ -227,6 +228,7 @@ class Backprop:
             self.relu_outputs.append(output)
 
         def _clip_gradients(module, grad_in, grad_out):
+            if not self.relu_outputs: return
             relu_output = self.relu_outputs.pop()
             clippled_grad_out = grad_out[0].clamp(0.0)
 


### PR DESCRIPTION
After producing visualizations, these hooks will remain registered with the model, and when a user tries to backprop any parameter with gradient disabled, it will cause problems. Specifically, `grad_in[0]` in `_record_gradients` will be None, and `_record_output` may not be triggered. We can remind users to unregister those hooks after using flashtorch, but a simple thing that we could do is to skip those hooks by based on some checks.